### PR TITLE
[fix] 메뉴바- Mobile 반응형 폰트 크기 조정

### DIFF
--- a/cuketmon/src/Menubar/Menubar.css
+++ b/cuketmon/src/Menubar/Menubar.css
@@ -77,4 +77,8 @@ body {
   .menubarItems {
     justify-content: flex-start;
   }
+
+  .menubarItems button a {
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
-기존 폰트 크기 적용시 글자가 줄 나눔이 되는 문제 발생
-폰트 크기를 12px로 제한해 문제 해결