### PR TITLE
[fix] local memory에서 테스트가 성공할 수 있도록 변경

### DIFF
--- a/BE/src/test/java/cuketmon/TestDummyDataConfig.java
+++ b/BE/src/test/java/cuketmon/TestDummyDataConfig.java
@@ -1,0 +1,67 @@
+package cuketmon;
+
+import cuketmon.monster.entity.Monster;
+import cuketmon.monster.repository.MonsterRepository;
+import cuketmon.trainer.embeddable.Feed;
+import cuketmon.trainer.embeddable.Toy;
+import cuketmon.trainer.entity.Trainer;
+import cuketmon.trainer.repository.TrainerRepository;
+import cuketmon.type.Type;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+public class TestDummyDataConfig {
+
+    @Autowired
+    private TrainerRepository trainerRepository;
+
+    @Autowired
+    private MonsterRepository monsterRepository;
+
+    @PostConstruct
+    public void initDummyData() {
+        trainerRepository.save(new Trainer("dummy_trainer", new Toy(), new Feed(), 0));
+        trainerRepository.save(new Trainer("kng", new Toy(), new Feed(), 0));
+
+        monsterRepository.save(Monster.builder()
+                .name("dummy_monster1")
+                .image(null)
+                .description("this is dummy monster1 for test")
+                .affinity(30)
+                .hp(89)
+                .speed(100)
+                .attack(83)
+                .defence(76)
+                .specialAttack(80)
+                .specialDefence(92)
+                .type1(Type.NORMAL)
+                .type2(Type.FIRE)
+                .skillId1(1)
+                .skillId2(2)
+                .skillId3(3)
+                .skillId4(4)
+                .build());
+
+        monsterRepository.save(Monster.builder()
+                .name("dummy_monster2")
+                .image(null)
+                .description("this is dummy monster2 for test")
+                .affinity(30)
+                .hp(89)
+                .speed(92)
+                .attack(83)
+                .defence(76)
+                .specialAttack(80)
+                .specialDefence(92)
+                .type1(Type.NORMAL)
+                .type2(Type.FIRE)
+                .skillId1(1)
+                .skillId2(2)
+                .skillId3(3)
+                .skillId4(4)
+                .build());
+    }
+
+}

--- a/BE/src/test/java/cuketmon/TestSkillDataConfig.java
+++ b/BE/src/test/java/cuketmon/TestSkillDataConfig.java
@@ -1,0 +1,85 @@
+package cuketmon;
+
+import cuketmon.damageclass.DamageClass;
+import cuketmon.skill.entity.Skill;
+import cuketmon.skill.repository.SkillRepository;
+import cuketmon.type.Type;
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestSkillDataConfig {
+
+    @Bean
+    public SkillDataInitializer skillDataInitializer(SkillRepository skillRepository) {
+        return new SkillDataInitializer(skillRepository);
+    }
+
+    public static class SkillDataInitializer {
+
+        private final SkillRepository skillRepository;
+
+        public SkillDataInitializer(SkillRepository skillRepository) {
+            this.skillRepository = skillRepository;
+        }
+
+        @PostConstruct
+        public void initSkills() {
+            skillRepository.save(new Skill(1, Type.WATER, DamageClass.SPECIAL, 100, "aqua-jet", 40, 20));
+            skillRepository.save(new Skill(2, Type.WATER, DamageClass.SPECIAL, 80, "hydro-pump", 90, 10));
+
+            skillRepository.save(new Skill(3, Type.GRASS, DamageClass.SPECIAL, 100, "razor-leaf", 55, 25));
+            skillRepository.save(new Skill(4, Type.GRASS, DamageClass.SPECIAL, 100, "solar-beam", 120, 10));
+
+            skillRepository.save(new Skill(5, Type.FIRE, DamageClass.SPECIAL, 100, "ember", 40, 25));
+            skillRepository.save(new Skill(6, Type.FIRE, DamageClass.SPECIAL, 100, "flamethrower", 90, 15));
+
+            skillRepository.save(new Skill(7, Type.ICE, DamageClass.SPECIAL, 100, "ice-beam", 90, 10));
+            skillRepository.save(new Skill(8, Type.ICE, DamageClass.SPECIAL, 70, "blizzard", 110, 5));
+
+            skillRepository.save(new Skill(9, Type.PSYCHIC, DamageClass.SPECIAL, 100, "psybeam", 65, 20));
+            skillRepository.save(new Skill(10, Type.PSYCHIC, DamageClass.SPECIAL, 100, "psychic", 90, 10));
+
+            skillRepository.save(new Skill(11, Type.FLYING, DamageClass.SPECIAL, 95, "air-slash", 75, 15));
+            skillRepository.save(new Skill(12, Type.FLYING, DamageClass.SPECIAL, 100, "gust", 40, 35));
+
+            skillRepository.save(new Skill(13, Type.GHOST, DamageClass.SPECIAL, 100, "shadow-ball", 80, 15));
+            skillRepository.save(new Skill(14, Type.GHOST, DamageClass.SPECIAL, 100, "hex", 65, 10));
+
+            skillRepository.save(new Skill(15, Type.ELECTRIC, DamageClass.SPECIAL, 100, "thunderbolt", 90, 15));
+            skillRepository.save(new Skill(16, Type.ELECTRIC, DamageClass.SPECIAL, 100, "spark", 65, 20));
+
+            skillRepository.save(new Skill(17, Type.DRAGON, DamageClass.SPECIAL, 100, "dragon-pulse", 85, 10));
+            skillRepository.save(new Skill(18, Type.DRAGON, DamageClass.SPECIAL, 90, "draco-meteor", 130, 5));
+
+            skillRepository.save(new Skill(19, Type.POISON, DamageClass.SPECIAL, 100, "sludge-bomb", 90, 10));
+            skillRepository.save(new Skill(20, Type.POISON, DamageClass.SPECIAL, 100, "acid", 40, 30));
+
+            skillRepository.save(new Skill(21, Type.NORMAL, DamageClass.SPECIAL, 100, "hyper-voice", 90, 10));
+            skillRepository.save(new Skill(22, Type.NORMAL, DamageClass.SPECIAL, 100, "round", 60, 15));
+
+            skillRepository.save(new Skill(23, Type.STEEL, DamageClass.SPECIAL, 100, "flash-cannon", 80, 10));
+            skillRepository.save(new Skill(24, Type.STEEL, DamageClass.SPECIAL, 90, "mirror-shot", 65, 10));
+
+            skillRepository.save(new Skill(25, Type.FAIRY, DamageClass.SPECIAL, 100, "moonblast", 95, 15));
+            skillRepository.save(new Skill(26, Type.FAIRY, DamageClass.SPECIAL, 100, "dazzling-gleam", 80, 10));
+
+            skillRepository.save(new Skill(27, Type.BUG, DamageClass.SPECIAL, 100, "bug-buzz", 90, 10));
+            skillRepository.save(new Skill(28, Type.BUG, DamageClass.SPECIAL, 100, "signal-beam", 75, 15));
+
+            skillRepository.save(new Skill(29, Type.ROCK, DamageClass.SPECIAL, 100, "power-gem", 80, 20));
+            skillRepository.save(new Skill(30, Type.ROCK, DamageClass.SPECIAL, 90, "ancient-power", 60, 5));
+
+            skillRepository.save(new Skill(31, Type.GROUND, DamageClass.SPECIAL, 100, "earth-power", 90, 10));
+            skillRepository.save(new Skill(32, Type.GROUND, DamageClass.SPECIAL, 85, "mud-shot", 55, 15));
+
+            skillRepository.save(new Skill(33, Type.DARK, DamageClass.SPECIAL, 100, "dark-pulse", 80, 15));
+            skillRepository.save(new Skill(34, Type.DARK, DamageClass.SPECIAL, 100, "fiery-wrath", 90, 10));
+
+            skillRepository.save(new Skill(35, Type.FIGHTING, DamageClass.SPECIAL, 100, "aura-sphere", 80, 20));
+            skillRepository.save(new Skill(36, Type.FIGHTING, DamageClass.SPECIAL, 70, "focus-blast", 120, 5));
+        }
+    }
+
+}

--- a/BE/src/test/java/cuketmon/battle/service/BattleMatchServiceTest.java
+++ b/BE/src/test/java/cuketmon/battle/service/BattleMatchServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import cuketmon.TestDummyDataConfig;
+import cuketmon.TestSkillDataConfig;
 import cuketmon.battle.dto.MatchResponse;
 import cuketmon.battle.dto.SkillRequest;
 import cuketmon.battle.dto.TrainerRequest;
@@ -18,12 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
+@Import({TestSkillDataConfig.class, TestDummyDataConfig.class})
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-class BattleMatchServiceIntegrationTest {
+class BattleMatchServiceTest {
 
     @Autowired
     private BattleMatchService battleMatchService;
@@ -33,7 +37,7 @@ class BattleMatchServiceIntegrationTest {
 
     @Test
     void 대기자가_없으면_대기열에_등록된다() {
-        TrainerRequest trainer = new TrainerRequest("kng", 1);
+        TrainerRequest trainer = new TrainerRequest("dummy_trainer", 1);
 
         battleMatchService.findBattle(trainer);
 

--- a/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
+++ b/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
@@ -2,6 +2,8 @@ package cuketmon.monster.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import cuketmon.TestDummyDataConfig;
+import cuketmon.TestSkillDataConfig;
 import cuketmon.monster.entity.Monster;
 import cuketmon.monster.repository.MonsterRepository;
 import cuketmon.trainer.entity.Trainer;
@@ -10,12 +12,10 @@ import cuketmon.trainer.service.TrainerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.annotation.Import;
 
+@Import({TestSkillDataConfig.class, TestDummyDataConfig.class})
 @SpringBootTest
-@Transactional
-@Rollback
 class MonsterServiceTest {
 
     @Autowired

--- a/BE/src/test/java/cuketmon/skill/service/SkillServiceTest.java
+++ b/BE/src/test/java/cuketmon/skill/service/SkillServiceTest.java
@@ -3,13 +3,17 @@ package cuketmon.skill.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import cuketmon.TestDummyDataConfig;
+import cuketmon.TestSkillDataConfig;
 import cuketmon.damageclass.DamageClass;
 import cuketmon.skill.entity.Skill;
 import cuketmon.type.Type;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
+@Import({TestSkillDataConfig.class, TestDummyDataConfig.class})
 @SpringBootTest
 class SkillServiceTest {
 

--- a/BE/src/test/java/cuketmon/util/DamageTest.java
+++ b/BE/src/test/java/cuketmon/util/DamageTest.java
@@ -2,6 +2,8 @@ package cuketmon.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import cuketmon.TestDummyDataConfig;
+import cuketmon.TestSkillDataConfig;
 import cuketmon.battle.TeamMaker;
 import cuketmon.battle.dto.BattleDTO;
 import cuketmon.battle.dto.TrainerRequest;
@@ -10,7 +12,9 @@ import cuketmon.skill.service.SkillService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
+@Import({TestSkillDataConfig.class, TestDummyDataConfig.class})
 @SpringBootTest
 class DamageTest {
 


### PR DESCRIPTION
## 📂 작업 요약
<!-- 작업내용을 요약해주시면 됩니다. -->
- 더미 데이터를 생성하여 그것을 import함
- rds에 직접 접근하면 수정이 필요없었지만, 테스트 환경과 배포 환경을 구분하기 위한 작업
- h2 db로 gradlew clean test 통과


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
#127 