### PR TITLE
[fix] 생성화면- 특징 입력 최대 글자 수 조정

### DIFF
--- a/cuketmon/src/Make/Make.js
+++ b/cuketmon/src/Make/Make.js
@@ -76,7 +76,7 @@ function Make() {
 
         <div className="Q2">
           <img src="./Menubar/mypageicon.png" alt="포켓몬 아이콘" />
-          <h2>원하시는 포켓몬의 특징을 적어주세요.</h2>
+          <h2>커켓몬 특징을 나타내는 단어들을 적어주세요.</h2>
         </div>
 
         <div className="cukemonFeature">
@@ -84,13 +84,13 @@ function Make() {
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              maxLength={35}
+              maxLength={44}
               rows={5}
               cols={50}
-              placeholder="원하시는 포켓몬의 특징을 기입하세요."
+              placeholder="영어로 기입해주세요. 예시) beige, normal/flying, sharp-beaked bird"
             />
           </div>
-          <p>{description.length} / 35 자</p>
+          <p>{description.length} / 44 자</p>
         </div>
 
         <div className="submitButton">

--- a/cuketmon/src/NamePage/NamePage.css
+++ b/cuketmon/src/NamePage/NamePage.css
@@ -85,14 +85,12 @@
   position: absolute;
   left: 13%;
   top: 38%;
-  cursor: none;
 }
 
 .choiceButtons #buttonText2 {
   position: absolute;
   left: 46%;
   top: 38%;
-  cursor: none;
 }
 
 #remake:hover,


### PR DESCRIPTION

## 📂 작업 요약
- 특징을 나타내는 단어들을 입력받아, 사용자가 원하는 내용을 글로 적지 않아도 되게함
- 특징 기입칸 입력 가능 최대 글자 수 증대. 기존 35자는 원하는 커켓몬의 특징을 나타내는데 한계가 존재했음.
- 이름 지정화면 하단 버튼 클릭시 마우스가 나타나지 않던 문제 해결.



## 📎 Issue
#134 #57 