### PR TITLE
[fix] 생성결과화면- 커켓몬 생성 실패시 이동할 페이지 수정

### DIFF
--- a/cuketmon/src/MakeResult/MakeResult.js
+++ b/cuketmon/src/MakeResult/MakeResult.js
@@ -34,8 +34,12 @@ function MakeResult() {
   }, [monsterId, location, API_URL]);
 
   const handleTextClick = () => {
-    const token = localStorage.getItem('token');
-    navigate("/makepage?token="+token);
+    const token = localStorage.getItem('jwt');
+    navigate(`/makepage?token=${token}`);
+    if (!token) {
+      alert("토큰이 없습니다.");
+      return;
+    }
   };
 
   return (


### PR DESCRIPTION


## 📂 작업 요약
- 커켓몬 생성 실패 시, navigate를 사용하여 /makepage 페이지로 이동함.
- 해당 페이지는 token을 전달하여 인증을 유지하도록 함



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
