### PR TITLE
[feat] 생성결과화면- 모바일 반응형 구현 및 임시코드 삭제

### DIFF
--- a/cuketmon/src/Make/Make.js
+++ b/cuketmon/src/Make/Make.js
@@ -61,7 +61,6 @@ function Make() {
     } catch (error) {
       console.error("에러 발생:", error);
       alert("서버와의 통신 중 오류가 발생했습니다.");
-      navigate("/MakeResult");
     }
   };
 

--- a/cuketmon/src/MakeResult/MakeResult.css
+++ b/cuketmon/src/MakeResult/MakeResult.css
@@ -20,7 +20,6 @@
   background-image: url("/public/MakeResultPage/chatBox.png");
   width: 60%;
   height: 25%;
-
   margin-left: 20%;
   background-size: contain;
   background-position: center;
@@ -53,4 +52,23 @@
 }
 .blinkEffect {
   animation: blinkEffect 2s ease-in-out 4;
+}
+
+/* 반응형 */
+@media (max-width: 767px) {
+  .resultPage #egg {
+    top: 37vh;
+    left: 25vw;
+    width: 50%;
+  }
+
+  .chatBox {
+    position: relative;
+    width: 100vw;
+    top: 30vh;
+    margin-left: 0;
+  }
+  .chatBox #ment {
+    top: 33%;
+  }
 }

--- a/cuketmon/src/MakeResult/MakeResult.js
+++ b/cuketmon/src/MakeResult/MakeResult.js
@@ -19,7 +19,7 @@ function MakeResult() {
         if (!monsterId || !token) return;
 
         try {
-          const response = await fetch(`${API_URL}/monster/${monsterId}/info`, {
+          const response = await fetch(`${API_URL}/api/monster/${monsterId}/info`, {
             method: "GET",
             headers: {
               Authorization: `Bearer ${token}`,
@@ -60,7 +60,7 @@ function MakeResult() {
       return;
     }
 
-    navigate(`/NamePage?token=${token}`, {
+    navigate(`/NamePage`, {
       state: {
         monsterId: monsterId,
         image: base64Image,


### PR DESCRIPTION


## 📂 작업 요약
- 임시 코드(navigate("/MakeResult");) 삭제
- 생성결과 화면 모바일 반응형 구현 완료
- 토큰이 붙은 이름 지정 페이지 url로 이동하는 문제 해결



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
