### PR TITLE
[fix] 마이페이지- 커켓몬 배열 초기화 및 커켓몬ID 로딩 추가

### DIFF
--- a/cuketmon/src/MyPage/MyPage.js
+++ b/cuketmon/src/MyPage/MyPage.js
@@ -11,7 +11,7 @@ function MyPage() {
   const [loading, setLoading] = useState(true);
   const [cukemonData, setCukemonData] = useState(null);
   const [monsterId, setMonsterId] = useState();
-  const [monsters, setMonsters] = useState(); 
+  const [monsters, setMonsters] = useState([]); 
   const API_URL = process.env.REACT_APP_API_URL;
   const { token } = useAuth();
 
@@ -31,6 +31,9 @@ function MyPage() {
       console.error("커켓몬 로딩에 실패했습니다.", error.message);
     }
   };
+  useEffect(() => {
+    loadCukemon();
+  }, []);
 
   /*먹이, 장난감 기저 상태 불러오기*/
   const loadTrainerData = async () => {


### PR DESCRIPTION


## 📂 작업 요약
- monsters 상태 빈 배열로 초기화
- loadCukemon으로 사용자 소유 커켓몬의 몬스터 id를 받아오도록함



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
