### PR TITLE
[fix] 마이페이지- 배열 로직 및 상태 추가

### DIFF
--- a/cuketmon/src/MyPage/MyPage.js
+++ b/cuketmon/src/MyPage/MyPage.js
@@ -6,8 +6,8 @@ import { useAuth } from '../AuthContext';
 function MyPage() {
   const [toyCount, setToyCount] = useState();
   const [feedCount, setFeedCount] = useState();
-  const [setIsFed] = useState(false);
-  const [setIsPlayed] = useState(false);
+  const [isFed,setIsFed] = useState(false);
+  const [isPlayed, setIsPlayed] = useState(false);
   const [loading, setLoading] = useState(true);
   const [cukemonData, setCukemonData] = useState(null);
   const [monsterId, setMonsterId] = useState();
@@ -24,7 +24,7 @@ function MyPage() {
         headers: { 'Authorization': `Bearer ${token}` },
       });
       const data = await res.json();
-      const monsterIds = data.id;
+      const monsterIds = Array.isArray(data.id) ? data.id : [data.id];
       setMonsters(monsterIds);     
       setMonsterId(0);             
     } catch (error) {


### PR DESCRIPTION


## 📂 작업 요약
- data.id 값이 배열인지 아닌지를 체크하여, 배열일 경우 그대로 배열로 설정하고, 배열이 아닐 경우 하나의 값으로 배열로 감싸는 로직을 추가
- 이전에는 isPlayed 상태를 선언하지 않았거나 사용되지 않았으나, 이제 isPlayed 상태를 선언하고, 이를 활용하여 플레이 애니메이션 등을 제어함


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
