### PR TITLE
[fix] 랭킹화면- 백엔드 연동 코드 수정 및 css 수정

### DIFF
--- a/cuketmon/src/Ranking/Ranking.css
+++ b/cuketmon/src/Ranking/Ranking.css
@@ -2,22 +2,22 @@
   background-image: url("/public/RankingPage/background.webp");
   background-size: cover;
   background-repeat: no-repeat;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
 }
 
 .rankingBoard {
+  position: absolute;
   text-align: center;
   font-size: 17px;
   width: 100%;
-  padding-bottom: 14%;
+  top: 10%;
 }
 
 .rankingBoard img {
   position: relative;
-  width: 10%;
-  height: 10%;
-  margin-top: 29%;
+  width: 14%;
+  height: 14%;
 }
 
 .rankingBoard .Myrank {
@@ -36,14 +36,12 @@
 
 .historyBoard th {
   font-family: "NeoDunggeunmo";
-
   background-color: white;
   padding: 14.8px;
 }
 
 .historyBoard td {
   font-family: "NeoDunggeunmo";
-
   background-color: white;
   text-align: center;
   padding: 10px;
@@ -62,6 +60,7 @@
   background-color: #00aeb5;
   color: white;
 }
+
 /*모바일 반응형*/
 @media (max-width: 767px) {
   #root,
@@ -73,21 +72,25 @@
   .ranking {
     height: 100%;
     background-image: url("/public/RankingPage/backgroundMobile.webp");
+    flex-direction: column;
+    justify-content: center;
+    padding-top: 0%;
+    height: 100%;
   }
 
   .rankingBoard {
-    padding-top: 30%;
     font-size: 17px;
+    top: 20%;
+    padding-bottom: 0;
   }
 
   .rankingBoard img {
-    width: 25%;
+    width: 30%;
     margin-bottom: 3%;
   }
 
   .historyBoard {
     width: 70%;
     margin-left: 15%;
-    margin-bottom: 38.9%;
   }
 }

--- a/cuketmon/src/Ranking/Ranking.js
+++ b/cuketmon/src/Ranking/Ranking.js
@@ -3,53 +3,71 @@ import MenuBar from "../Menubar/Menubar.js";
 import './Ranking.css';
 
 function Ranking() {
-  const [Myrank, setMyrank] = useState(0);
-  const [battleCount, setBattleCount] = useState(0);
+  const [rank, setRank] = useState(0); 
+  const [trainerName, setTrainerName] = useState(''); 
   const [winCount, setWinCount] = useState(0);
-  const [imageUrl, setImageUrl] = useState('/Menubar/egg.webp');
+  const [loseCount, setLoseCount] = useState(0); 
+  const [battleCount, setBattleCount] = useState(0);
+  const [imageUrl, setImageUrl] = useState('/Menubar/egg.webp'); // 전투 API 사용할 수 있을지 확인 필요
+  const API_URL = process.env.REACT_APP_API_URL;
+  const token = localStorage.getItem('token'); 
 
-
-  const trainerName = "xami"; //임시로 xami로 둠. 나중에 카카오 로그인 연동 후 각 사용자 이름을 받아오게 만들것!!
   useEffect(() => {
-    fetch(`/${trainerName}/rank`) 
-      .then(response => response.json())
-      .then(data => {
-        setMyrank(data.rank);
-        setBattleCount(data.battleCount);
-        setWinCount(data.winCount);
-        setImageUrl(data.imageUrl); 
-      })
-      .catch(error => console.error('Error fetching ranking data:', error));
-  }, []);
+    const fetchRankingData = async () => {
+      try {
+        const response = await fetch(`${API_URL}/api/ranking`, {
+          method: 'GET', 
+          headers: {
+            'Authorization': `Bearer ${token}`
+          }
+        });
+        const data = await response.json();
+
+        console.log(data)
+        setRank(data.rank);
+        setTrainerName(data.trainerName);
+        setWinCount(data.win);
+        setLoseCount(data.lose);
+        setBattleCount(data.allBattles);
+      } catch (error) {
+        console.error('Error fetching ranking data:', error);
+      }
+    };
+    fetchRankingData();
+  }, [API_URL, token]);
 
   return (
     <div className='ranking'>
-    <div className='rankingBoard'>
-      <img src={imageUrl} alt='최근 사용 커켓몬' className="pokemonImage" />
-  <table className="historyBoard">
-    <thead>
-      <tr>
-        <th>Standing</th>
-        <th>No. {Myrank}</th>
-      </tr>
-    </thead>
-    <tbody>
-  <tr>
-    <td className='mark1'>No. of Battles</td>
-    <td>{battleCount}</td>
-  </tr>
-  <tr>
-    <td className='mark2'>Wins</td>
-    <td>{winCount}</td>
-  </tr>
-  <tr>
-    <td className='mark3'>Losses</td>
-    <td>{battleCount - winCount}</td>
-  </tr>
-</tbody>
-  </table>
-    </div>      
-    <MenuBar />
+      <div className='rankingBoard'>
+        <img src={imageUrl} alt='최근 사용 커켓몬' className="pokemonImage" />
+        <table className="historyBoard">
+          <thead>
+            <tr>
+              <th>Standing</th>
+              <th>No. {rank}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className='mark1'>Trainer Name</td>
+              <td>{trainerName}</td>
+            </tr>
+            <tr>
+              <td className='mark1'>No. of Battles</td>
+              <td>{battleCount}</td>
+            </tr>
+            <tr>
+              <td className='mark2'>Wins</td>
+              <td>{winCount}</td>
+            </tr>
+            <tr>
+              <td className='mark3'>Losses</td>
+              <td>{loseCount}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>      
+      <MenuBar />
     </div>
   );
 }


### PR DESCRIPTION


## 📂 작업 요약
- 백엔드 연동 코드 엔드포인트를 수정함
- 백엔드 연동 코드 trainerName 삭제
- 커켓몬 이미지를 크기 증가
- Ranking.css에서 필요없는 패딩을 삭제함



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
