### PR TITLE
[feat] 자신의 커켓몬에 대한 요청만 허용하는 기능 구현

### DIFF
--- a/BE/src/main/java/cuketmon/constant/message/ErrorMessages.java
+++ b/BE/src/main/java/cuketmon/constant/message/ErrorMessages.java
@@ -9,4 +9,6 @@ public class ErrorMessages {
     public static final String FEED_INVALID_AMOUNT = "[ERROR] 남은 먹이가 부족합니다.";
     public static final String TOY_INVALID_AMOUNT = "[ERROR] 남은 장난감이 부족합니다.";
 
+    public static final String MONSTER_INVALID_OWNER = "[ERROR] 당신의 커켓몬이 아닙니다!";
+
 }

--- a/BE/src/main/java/cuketmon/constant/message/InfoMessages.java
+++ b/BE/src/main/java/cuketmon/constant/message/InfoMessages.java
@@ -1,0 +1,10 @@
+package cuketmon.constant.message;
+
+public class InfoMessages {
+
+    public static final String NAME_CHANGE_SUCCESS = "[INFO ] 커켓몬 이름 변경 성공!";
+    public static final String FEED_SUCCESS = "[INFO ] 먹이를 주었습니다!";
+    public static final String PLAY_SUCCESS = "[INFO ] 놀아주었습니다!";
+    public static final String RELEASE_SUCCESS = "[INFO ] 놓아주었습니다!";
+
+}

--- a/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
+++ b/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
@@ -44,10 +44,11 @@ public class MonsterController {
 
     // 커켓몬 이름 지정
     @PatchMapping("/{monsterId}/name")
-    public ResponseEntity<String> namingMonster(@PathVariable Integer monsterId,
+    public ResponseEntity<String> namingMonster(@AuthenticationPrincipal String trainerName,
+                                                @PathVariable Integer monsterId,
                                                 @Validated @RequestBody NamingDTO monsterName) {
         try {
-            monsterService.naming(monsterId, monsterName.getName());
+            monsterService.naming(trainerName, monsterId, monsterName.getName());
             return ResponseEntity.ok(NAME_CHANGE_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -56,9 +57,10 @@ public class MonsterController {
 
     // 커켓몬 놓아주기
     @DeleteMapping("/{monsterId}/release")
-    public ResponseEntity<String> releaseMonster(@PathVariable Integer monsterId) {
+    public ResponseEntity<String> releaseMonster(@AuthenticationPrincipal String trainerName,
+                                                 @PathVariable Integer monsterId) {
         try {
-            monsterService.release(monsterId);
+            monsterService.release(trainerName, monsterId);
             return ResponseEntity.ok(RELEASE_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());

--- a/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
+++ b/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
@@ -1,5 +1,10 @@
 package cuketmon.monster.controller;
 
+import static cuketmon.constant.message.InfoMessages.FEED_SUCCESS;
+import static cuketmon.constant.message.InfoMessages.NAME_CHANGE_SUCCESS;
+import static cuketmon.constant.message.InfoMessages.PLAY_SUCCESS;
+import static cuketmon.constant.message.InfoMessages.RELEASE_SUCCESS;
+
 import cuketmon.monster.dto.GenerateApiRequestBody;
 import cuketmon.monster.dto.NamingDTO;
 import cuketmon.monster.service.MonsterService;
@@ -43,7 +48,7 @@ public class MonsterController {
                                                 @Validated @RequestBody NamingDTO monsterName) {
         try {
             monsterService.naming(monsterId, monsterName.getName());
-            return ResponseEntity.ok("커켓몬 이름 변경 성공!");
+            return ResponseEntity.ok(NAME_CHANGE_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
@@ -54,7 +59,7 @@ public class MonsterController {
     public ResponseEntity<String> releaseMonster(@PathVariable Integer monsterId) {
         try {
             monsterService.release(monsterId);
-            return ResponseEntity.ok("커켓몬 놓아주기 성공!");
+            return ResponseEntity.ok(RELEASE_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
@@ -66,7 +71,7 @@ public class MonsterController {
                                               @PathVariable Integer monsterId) {
         try {
             monsterService.feed(trainerName, monsterId);
-            return ResponseEntity.ok("먹이를 주었습니다.");
+            return ResponseEntity.ok(FEED_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
@@ -78,7 +83,7 @@ public class MonsterController {
                                                   @PathVariable Integer monsterId) {
         try {
             monsterService.play(trainerName, monsterId);
-            return ResponseEntity.ok("놀아주었습니다.");
+            return ResponseEntity.ok(PLAY_SUCCESS);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/BE/src/main/java/cuketmon/trainer/controller/TrainerController.java
+++ b/BE/src/main/java/cuketmon/trainer/controller/TrainerController.java
@@ -38,11 +38,11 @@ public class TrainerController {
     }
 
     // 랭킹 시스템
-    //전체 트레이너 랭킹
-//    @GetMapping("/ranking")
-//    public ResponseEntity<List<TrainerDTO>> getTrainerRanking() {
-//        return ResponseEntity.ok(trainerService.getTrainerRanking());
-//    }
+    // 전체 트레이너 랭킹
+    // @GetMapping("/ranking")
+    // public ResponseEntity<List<TrainerDTO>> getTrainerRanking() {
+    // return ResponseEntity.ok(trainerService.getTrainerRanking());
+    // }
 
     @PostMapping("/ranking")
     public ResponseEntity<List<TrainerDTO>> getTrainerRanking(@RequestBody TrainerDTO request) {
@@ -50,15 +50,15 @@ public class TrainerController {
     }
 
     //개인 트레이너 개별 랭킹
-//    @GetMapping("/raking/{trainerName}")
-//    public ResponseEntity<?> getSingleRanking(@PathVariable String trainerName) {
-//        try{
-//            TrainerDTO dto = trainerService.getSingleRanking(trainerName);
-//            return ResponseEntity.ok(dto);
-//        } catch (NoSuchElementException e) {
-//            return ResponseEntity.status(404).body(Map.of("[ERROR]", e.getMessage()));
-//        }
-//    }
+    // @GetMapping("/raking/{trainerName}")
+    // public ResponseEntity<?> getSingleRanking(@PathVariable String trainerName) {
+    //    try{
+    //        TrainerDTO dto = trainerService.getSingleRanking(trainerName);
+    //        return ResponseEntity.ok(dto);
+    //    } catch (NoSuchElementException e) {
+    //        return ResponseEntity.status(404).body(Map.of("[ERROR]", e.getMessage()));
+    //    }
+    // }
 
     @PostMapping("/ranking/{trainerName}")
     public ResponseEntity<?> getSingleRanking(@RequestBody TrainerDTO request) {

--- a/BE/src/main/java/cuketmon/trainer/embeddable/Toy.java
+++ b/BE/src/main/java/cuketmon/trainer/embeddable/Toy.java
@@ -1,7 +1,7 @@
 package cuketmon.trainer.embeddable;
 
 import static cuketmon.constant.message.ErrorMessages.TOY_INVALID_AMOUNT;
-import static cuketmon.trainer.constant.TrainerConst.INIT_FEED_COUNT;
+import static cuketmon.trainer.constant.TrainerConst.INIT_TOY_COUNT;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
@@ -13,7 +13,7 @@ public class Toy {
     private Integer count;
 
     public Toy() {
-        this.count = INIT_FEED_COUNT;
+        this.count = INIT_TOY_COUNT;
     }
 
     public int decrease(int amount) {

--- a/BE/src/main/java/cuketmon/trainer/entity/Trainer.java
+++ b/BE/src/main/java/cuketmon/trainer/entity/Trainer.java
@@ -41,7 +41,7 @@ public class Trainer {
     })
     private Feed feed;
 
-    //랭킹 시스템
+    // 랭킹 시스템
     @Column(nullable = false)
     private Integer win;
 

--- a/BE/src/test/java/cuketmon/config/TestDummyDataConfig.java
+++ b/BE/src/test/java/cuketmon/config/TestDummyDataConfig.java
@@ -28,20 +28,23 @@ public class TestDummyDataConfig {
 
     @PostConstruct
     public void initDummyData() {
-        trainerRepository.save(Trainer.builder()
+        Trainer trainer1 = Trainer.builder()
                 .name(TRAINER1)
                 .toy(new Toy())
                 .feed(new Feed())
                 .win(0)
                 .lose(0)
-                .build());
-        trainerRepository.save(Trainer.builder()
+                .build();
+        Trainer trainer2 = Trainer.builder()
                 .name(TRAINER2)
                 .toy(new Toy())
                 .feed(new Feed())
                 .win(0)
                 .lose(0)
-                .build());
+                .build();
+
+        trainerRepository.save(trainer1);
+        trainerRepository.save(trainer2);
 
         monsterRepository.save(Monster.builder()
                 .name(MONSTER1)
@@ -60,6 +63,7 @@ public class TestDummyDataConfig {
                 .skillId2(2)
                 .skillId3(3)
                 .skillId4(4)
+                .trainer(trainer1)
                 .build());
         monsterRepository.save(Monster.builder()
                 .name(MONSTER2)
@@ -78,6 +82,7 @@ public class TestDummyDataConfig {
                 .skillId2(2)
                 .skillId3(3)
                 .skillId4(4)
+                .trainer(trainer2)
                 .build());
     }
 

--- a/BE/src/test/java/cuketmon/constant/TestConfig.java
+++ b/BE/src/test/java/cuketmon/constant/TestConfig.java
@@ -2,8 +2,8 @@ package cuketmon.constant;
 
 public class TestConfig {
 
-    public static final String TRAINER1 = "kng";
-    public static final String TRAINER2 = "dummy_trainer";
+    public static final String TRAINER1 = "dummy_trainer1";
+    public static final String TRAINER2 = "dummy_trainer2";
 
     public static final String MONSTER1 = "dummy_monster1";
     public static final String MONSTER2 = "dummy_monster1";

--- a/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
+++ b/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
@@ -1,7 +1,9 @@
 package cuketmon.monster.service;
 
 import static cuketmon.constant.TestConfig.TRAINER1;
+import static cuketmon.constant.TestConfig.TRAINER2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import cuketmon.config.TestDummyDataConfig;
 import cuketmon.config.TestSkillDataConfig;
@@ -62,6 +64,13 @@ class MonsterServiceTest {
 
         Monster updatedMonster = monsterRepository.findById(1).get();
         assertEquals(prevAffinity + 1, updatedMonster.getAffinity().getCount());
+    }
+
+    @Test
+    void 자신의_커켓몬이_아닐경우_오류를_발생시킨다() {
+        assertThrows(IllegalArgumentException.class, () -> monsterService.play(TRAINER2, 1));
+        assertThrows(IllegalArgumentException.class, () -> monsterService.feed(TRAINER2, 1));
+        assertThrows(IllegalArgumentException.class, () -> monsterService.naming(TRAINER2, 1, "temp"));
     }
 
 }

--- a/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
+++ b/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
@@ -1,5 +1,6 @@
 package cuketmon.monster.service;
 
+import static cuketmon.constant.TestConfig.TRAINER1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cuketmon.config.TestDummyDataConfig;
@@ -32,23 +33,23 @@ class MonsterServiceTest {
 
     @Test
     void 먹이가_올바르게_차감되어_DB에_저장되고_조회된다() {
-        Trainer trainer = trainerRepository.findById("kng").get();
+        Trainer trainer = trainerRepository.findById(TRAINER1).get();
         int prevFeed = trainer.getFeed().getCount();
 
-        monsterService.feed("kng", 1);
+        monsterService.feed(TRAINER1, 1);
 
-        Trainer updatedTrainer = trainerRepository.findById("kng").get();
+        Trainer updatedTrainer = trainerRepository.findById(TRAINER1).get();
         assertEquals(prevFeed - 1, updatedTrainer.getFeed().getCount());
     }
 
     @Test
     void 장난감이_올바르게_차감되어_DB에_저장되고_조회된다() {
-        Trainer trainer = trainerRepository.findById("kng").get();
+        Trainer trainer = trainerRepository.findById(TRAINER1).get();
         int prevToy = trainer.getToy().getCount();
 
-        monsterService.play("kng", 1);
+        monsterService.play(TRAINER1, 1);
 
-        Trainer updatedTrainer = trainerRepository.findById("kng").get();
+        Trainer updatedTrainer = trainerRepository.findById(TRAINER1).get();
         assertEquals(prevToy - 1, updatedTrainer.getToy().getCount());
     }
 
@@ -57,7 +58,7 @@ class MonsterServiceTest {
         Monster monster = monsterRepository.findById(1).get();
         int prevAffinity = monster.getAffinity().getCount();
 
-        monsterService.play("kng", 1);
+        monsterService.play(TRAINER1, 1);
 
         Monster updatedMonster = monsterRepository.findById(1).get();
         assertEquals(prevAffinity + 1, updatedMonster.getAffinity().getCount());


### PR DESCRIPTION
## 📂 작업 요약
<!-- 작업내용을 요약해주시면 됩니다. -->
- 자신의 커켓몬이 아닌 커켓몬을 놓아주는 등의 접근을 막음
- api 요청시 validate 하여 현재 유저의 monster인지 탐지함


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
#257 