### PR TITLE
[feat] 유저당 보유 커켓몬 수를 제한하는 기능 구현

### DIFF
--- a/BE/src/main/java/cuketmon/constant/message/ErrorMessages.java
+++ b/BE/src/main/java/cuketmon/constant/message/ErrorMessages.java
@@ -6,6 +6,8 @@ public class ErrorMessages {
     public static final String MONSTER_NOT_FOUND = "[ERROR] 해당 커켓몬을 찾을 수 없습니다.";
     public static final String SKILL_NOT_FOUND = "[ERROR] 해당 ID의 스킬이 없습니다.";
 
+    public static final String MONSTER_LIMIT_EXCEEDED = "[ERROR] 커켓몬은 최대 5마리까지 지닐 수 있습니다.";
+
     public static final String FEED_INVALID_AMOUNT = "[ERROR] 남은 먹이가 부족합니다.";
     public static final String TOY_INVALID_AMOUNT = "[ERROR] 남은 장난감이 부족합니다.";
 

--- a/BE/src/main/java/cuketmon/monster/constant/MonsterConst.java
+++ b/BE/src/main/java/cuketmon/monster/constant/MonsterConst.java
@@ -2,6 +2,8 @@ package cuketmon.monster.constant;
 
 public class MonsterConst {
 
+    public static final int MAX_MONSTER_LIMIT = 5;
+
     public static final int MIN_BASE = 60;
     public static final int MAX_BASE = 100;
 

--- a/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
+++ b/BE/src/main/java/cuketmon/monster/controller/MonsterController.java
@@ -38,8 +38,12 @@ public class MonsterController {
     @PostMapping("/generate")
     public ResponseEntity<Map<String, Integer>> generateMonster(@AuthenticationPrincipal String trainerName,
                                                                 @Validated @RequestBody GenerateApiRequestBody requestBody) {
-        Integer monsterId = monsterService.generate(trainerName, requestBody);
-        return ResponseEntity.ok(Map.of("monsterId", monsterId));
+        try {
+            Integer monsterId = monsterService.generate(trainerName, requestBody);
+            return ResponseEntity.ok(Map.of("monsterId", monsterId));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of(e.getMessage(), 400));
+        }
     }
 
     // 커켓몬 이름 지정

--- a/BE/src/main/java/cuketmon/monster/service/MonsterService.java
+++ b/BE/src/main/java/cuketmon/monster/service/MonsterService.java
@@ -1,12 +1,14 @@
 package cuketmon.monster.service;
 
 import static cuketmon.constant.message.ErrorMessages.MONSTER_INVALID_OWNER;
+import static cuketmon.constant.message.ErrorMessages.MONSTER_LIMIT_EXCEEDED;
 import static cuketmon.constant.message.ErrorMessages.MONSTER_NOT_FOUND;
 import static cuketmon.constant.message.ErrorMessages.TRAINER_NOT_FOUND;
 import static cuketmon.monster.constant.MonsterConst.AFFINITY_PLUS;
 import static cuketmon.monster.constant.MonsterConst.FEED_MINUS;
 import static cuketmon.monster.constant.MonsterConst.MAX_BASE;
 import static cuketmon.monster.constant.MonsterConst.MAX_DAMAGE;
+import static cuketmon.monster.constant.MonsterConst.MAX_MONSTER_LIMIT;
 import static cuketmon.monster.constant.MonsterConst.MID_DAMAGE;
 import static cuketmon.monster.constant.MonsterConst.MIN_BASE;
 import static cuketmon.monster.constant.MonsterConst.MIN_DAMAGE;
@@ -57,6 +59,10 @@ public class MonsterService {
     public Integer generate(String trainerName, GenerateApiRequestBody requestBody) {
         Trainer trainer = trainerRepository.findById(trainerName)
                 .orElseThrow(() -> new IllegalArgumentException(TRAINER_NOT_FOUND));
+
+        if (trainer.getMonsters().size() >= MAX_MONSTER_LIMIT) {
+            throw new IllegalArgumentException(MONSTER_LIMIT_EXCEEDED);
+        }
 
         Type type1 = Type.fromString(requestBody.getType1());
         Type type2 = Type.fromString(requestBody.getType2()); // nullable 값

--- a/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
+++ b/BE/src/test/java/cuketmon/monster/service/MonsterServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import cuketmon.config.TestDummyDataConfig;
 import cuketmon.config.TestSkillDataConfig;
+import cuketmon.monster.dto.GenerateApiRequestBody;
 import cuketmon.monster.entity.Monster;
 import cuketmon.monster.repository.MonsterRepository;
 import cuketmon.trainer.entity.Trainer;
@@ -71,6 +72,19 @@ class MonsterServiceTest {
         assertThrows(IllegalArgumentException.class, () -> monsterService.play(TRAINER2, 1));
         assertThrows(IllegalArgumentException.class, () -> monsterService.feed(TRAINER2, 1));
         assertThrows(IllegalArgumentException.class, () -> monsterService.naming(TRAINER2, 1, "temp"));
+    }
+
+    @Test
+    void 커켓몬을_다섯마리_이상_보유할_시_오류를_발생시킨다() {
+        GenerateApiRequestBody body = new GenerateApiRequestBody("FIRE", "ELECTRIC", "temp");
+        monsterService.generate(TRAINER1, body);
+        monsterService.generate(TRAINER1, body);
+        monsterService.generate(TRAINER1, body);
+        monsterService.generate(TRAINER1, body);
+
+        // 5마리 제한 확인
+        // config에서 1마리 생성했으므로 4마리 추가 생성 후 assertThrows 테스트
+        assertThrows(IllegalArgumentException.class, () -> monsterService.generate(TRAINER1, body));
     }
 
 }


### PR DESCRIPTION
## 📂 작업 요약
<!-- 작업내용을 요약해주시면 됩니다. -->
- 유저는 5마리의 커켓몬을 가질 수 있도록 함
- 테스트 완료


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
#259 