### PR TITLE
[feat] 랭킹화면- 랭킹보드위 커켓몬 이미지 추가

### DIFF
--- a/cuketmon/src/Ranking/Ranking.css
+++ b/cuketmon/src/Ranking/Ranking.css
@@ -14,10 +14,17 @@
   top: 10%;
 }
 
-.rankingBoard img {
+.cukemonImageContainer {
+  width: 42%;
+
   position: relative;
-  width: 14%;
-  height: 14%;
+  margin-top: 5%;
+  left: 28%;
+  transition: transform 0.2s;
+}
+
+.cukemonImage:hover {
+  transform: scale(1.05);
 }
 
 .rankingBoard .Myrank {
@@ -84,9 +91,9 @@
     padding-bottom: 0;
   }
 
-  .rankingBoard img {
-    width: 30%;
-    margin-bottom: 3%;
+  .cukemonImageContainer {
+    white-space: nowrap;
+    left: 18%;
   }
 
   .historyBoard {

--- a/cuketmon/src/Ranking/Ranking.js
+++ b/cuketmon/src/Ranking/Ranking.js
@@ -8,21 +8,68 @@ function Ranking() {
   const [winCount, setWinCount] = useState(0);
   const [loseCount, setLoseCount] = useState(0); 
   const [battleCount, setBattleCount] = useState(0);
-  const [imageUrl, setImageUrl] = useState('/Menubar/egg.webp'); // 전투 API 사용할 수 있을지 확인 필요
+  const [monsters, setMonsters] = useState([]);  
+  const [monsterImages, setMonsterImages] = useState([]);
   const API_URL = process.env.REACT_APP_API_URL;
   const token = localStorage.getItem('token'); 
 
+
+  /*유저 소유 커켓몬 id 배열로 받기 */
+  const loadCukemon = async () => {
+    if (!token) return;
+    try {
+      const res = await fetch(`${API_URL}/api/trainer/monsters`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      const data = await res.json();
+      const monsterIds = Array.isArray(data) ? data : [];  
+      setMonsters(monsterIds);     
+      console.log(monsterIds)            
+    } catch (error) {
+      console.error("커켓몬 로딩에 실패했습니다.", error.message);
+    }
+  };
+  useEffect(() => {
+    loadCukemon();
+  }, []);
+
+  useEffect(() => {
+    if (monsters.length > 0) {
+      loadCukemonImages(monsters);
+    }
+  }, [monsters]);
+
+  /*커켓몬몬 이미지 */
+  const loadCukemonImages = async (monsterIds) => {
+    try {
+      const imagePromises = monsterIds.map(async (monsterId) => {
+        const res = await fetch(`${API_URL}/api/monster/${monsterId}/info`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const data = await res.json();
+        return data?.image ? data.image : ''; 
+      });
+      
+      const images = await Promise.all(imagePromises); 
+      setMonsterImages(images); 
+    } catch (error) {
+      console.error("커켓몬 이미지 로딩에 실패했습니다.", error.message);
+    }
+  };
+
+
+
+  /*랭킹 */
   useEffect(() => {
     const fetchRankingData = async () => {
       try {
-        const response = await fetch(`${API_URL}/api/ranking`, {
+        const response = await fetch(`${API_URL}/api/trainer/ranking`, {
           method: 'GET', 
           headers: {
             'Authorization': `Bearer ${token}`
           }
         });
         const data = await response.json();
-
         console.log(data)
         setRank(data.rank);
         setTrainerName(data.trainerName);
@@ -36,10 +83,16 @@ function Ranking() {
     fetchRankingData();
   }, [API_URL, token]);
 
+
+
   return (
     <div className='ranking'>
       <div className='rankingBoard'>
-        <img src={imageUrl} alt='최근 사용 커켓몬' className="pokemonImage" />
+      <div className="cukemonImageContainer">
+      {monsterImages.map((url, idx) => (
+       <img key={idx} src={url} alt="우리의 든든한 커켓몬 군단" className="cukemonImage" />
+     ))}
+      </div>
         <table className="historyBoard">
           <thead>
             <tr>


### PR DESCRIPTION


## 📂 작업 요약
- 랭킹보드 바로 위에 커켓몬을 추가해 UI를 개선함
- Ranking.js에서 유저가 보유한 커켓몬 id를 받아오는 구조 구현
- Ranking.js에서 위에서 받아온 커켓몬들의 이미지를 표시할 수 있게 구현.



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
