### PR TITLE
[fix] 마이페이지- 글씨체 적용 오류 해결 및 텍스트 위치 조정

### DIFF
--- a/cuketmon/src/MyPage/MyPage.css
+++ b/cuketmon/src/MyPage/MyPage.css
@@ -55,6 +55,8 @@ span {
   background-color: #d9d9d9;
   margin-bottom: 3%;
   padding-bottom: 0.5%;
+  padding-top: 1%;
+  font-family: "NeoDunggeunmo";
 }
 
 .cucketmonProfile img {
@@ -90,7 +92,7 @@ span {
 
 #buttonText1 {
   position: absolute;
-  top: 54.3%;
+  top: 55.3%;
   left: 75.5vw;
   font-size: 18px;
   color: white;
@@ -101,7 +103,7 @@ span {
   position: absolute;
   pointer-events: none;
   font-size: 18px;
-  top: 54.3%;
+  top: 55.3%;
   left: 88vw;
 }
 

--- a/cuketmon/src/index.css
+++ b/cuketmon/src/index.css
@@ -1,13 +1,13 @@
 * {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    'NeoDunggeunmo', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "NeoDunggeunmo", "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", "NeoDunggeunmo", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'NeoDunggeunmo', 'Courier New',
-    monospace;
+  font-family: "NeoDunggeunmo", source-code-pro, Menlo, Monaco, Consolas,
+    "Courier New", monospace;
 }


### PR DESCRIPTION


## 📂 작업 요약
- 마이페이지에서 NeoDunggeunmo체 적용 오류 해결
- index.js에서 글씨체 우선순위를 변경(NeoDunggeunmo의 우선순위를 높임)
- 글씨체 변화로인한 mypage.css 세부조정 (버튼 텍스트 top조정, 커켓몬 프로필 박스 padding top 조정)



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
