### PR TITLE
[fix]랭킹화면- 모바일 반응형 커켓몬 이미지 컨테이너 크기 조정

### DIFF
--- a/cuketmon/src/Ranking/Ranking.css
+++ b/cuketmon/src/Ranking/Ranking.css
@@ -92,7 +92,8 @@
 
   .cukemonImageContainer {
     white-space: nowrap;
-    left: 10vw;
+    width: 100vw;
+    left: 0vw;
   }
 
   .historyBoard {


### PR DESCRIPTION


## 📂 작업 요약
- 모바일 랭킹화면에서 커켓몬 5마리 보유하면 화면이 넘쳐 레이아웃이 깨지는 문제가 있었음
- 커켓몬 이미지 컨테이너를 조정해 기존 문제 해결



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
