### PR TITLE
[fix] 랭킹화면- 커켓몬 이미지 조정

### DIFF
--- a/cuketmon/src/Ranking/Ranking.css
+++ b/cuketmon/src/Ranking/Ranking.css
@@ -95,6 +95,9 @@
     width: 100vw;
     left: 0vw;
   }
+  .cukemonImageContainer img {
+    width: 14vw;
+  }
 
   .historyBoard {
     width: 70%;


### PR DESCRIPTION


## 📂 작업 요약
- 일부 기기에서 커켓몬 container 속 이미지가 넘쳐 레이아웃이 깨지는 현상이 여전히 발생.
- 이를 해결하고자 .cukemonImageContainer속 이미지의 크기를 명시적으로 지정



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
