### PR TITLE
[fix] 마이페이지- 커켓몬 이미지 조정

### DIFF
--- a/cuketmon/src/MyPage/MyPage.css
+++ b/cuketmon/src/MyPage/MyPage.css
@@ -182,14 +182,14 @@ span {
 
   #cuketmonImage {
     position: absolute;
-    top: 41%;
+    top: 37%;
     width: 35%;
     left: 34%;
   }
 
   .cucketmonProfile {
     position: absolute;
-    top: 60%;
+    top: 57.5%;
     left: 34%;
     margin-left: 0;
     width: 35%;


### PR DESCRIPTION


## 📂 작업 요약
- 이름이 긴 경우 일부 기기에서 커켓몬 프로필과 버튼이 겹치는 문제 발생
- 이를 해결하고자 커켓몬 이미지 top 조정, 커켓몬 프로필창 top조정



## 📎 Issue
#288
