### PR TITLE
[fix] 이름지정화면- 커켓몬 재부화 오류 해결

### DIFF
--- a/cuketmon/src/NamePage/NamePage.js
+++ b/cuketmon/src/NamePage/NamePage.js
@@ -9,14 +9,12 @@ function NamePage() {
   const navigate = useNavigate();
   const { token: contextToken } = useAuth();
   const token = contextToken || localStorage.getItem('jwt');
-  const location = useLocation();
+  const location = useLocation(); 
   const maxLength = 12;
   const API_URL = process.env.REACT_APP_API_URL;
-
   const monsterId = location.state?.monsterId; 
   console.log(monsterId);
   const cukemonResultImage = location.state?.image; 
-  console.log(cukemonResultImage); //혹시나 url 확인용! 추후 뺌
 
   useEffect(() => {
     if (cukemonResultImage) {
@@ -56,9 +54,16 @@ function NamePage() {
     }
   };
 
+
   const handleGoTOMakePage = async()=>{
-    navigate(`/make`)
-  }
+        const res = await fetch(`${API_URL}/api/monster/${monsterId}/release`, {
+          method: "DELETE",
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error(`오류발생`);
+        navigate(`/make`)
+    }
+  
 
   return (
     <div className="namePage">


### PR DESCRIPTION


## 📂 작업 요약
- 기존에는 커켓몬 재부화를 눌러도 커켓몬이 마이페이지로 무단침입하는 문제가 있었음
- 이를 방출 api를 사용해 마이페이지에 강제 입양되는 커켓몬을 방출시켜서 문제를 해결함



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
