### PR TITLE
[fix] 이름지정화면- 뒤로가기 방지 오류 해결

### DIFF
--- a/cuketmon/src/NamePage/NamePage.js
+++ b/cuketmon/src/NamePage/NamePage.js
@@ -17,10 +17,12 @@ function NamePage() {
   const cukemonResultImage = location.state?.image; 
 
 //뒤로가기 막기 (5/9)
- useEffect(() => {
-  const preventGoBack = () => {
-    window.history.go(1); 
-    alert("커켓몬을 두고 떠나지마요 ㅠㅠㅠ");
+useEffect(() => {
+  const preventGoBack = (event) => {
+    if (event.type === "popstate") {
+      window.history.go(1);
+      alert("커켓몬을 두고 떠나지마요 ㅠㅠㅠ");
+    }
   };
   window.history.pushState(null, "", window.location.href);
   window.addEventListener("popstate", preventGoBack);


### PR DESCRIPTION


## 📂 작업 요약
- '커켓몬을 두고 떠나지마세요' 경고창이 2번뜨던 문제해결
- 마이페이지로 이동안되던 문제 해결 시도



## 📎 Issue
#309 