### PR TITLE
[fix] 생성화면- 커켓몬 이미지 전달 방식 변경 및 필요없는 로직 제거

### DIFF
--- a/cuketmon/src/Make/Make.js
+++ b/cuketmon/src/Make/Make.js
@@ -58,7 +58,7 @@ function Make() {
         const data = await response.json();
         const monsterId = data.monsterId;
         localStorage.setItem('makeResultMonsterId', monsterId);
-        navigate("/MakeResult", { state: { monsterId } }); 
+        navigate("/MakeResult"); 
       } else {
         alert("데이터 전송에 실패했습니다.");
       }

--- a/cuketmon/src/MakeResult/MakeResult.js
+++ b/cuketmon/src/MakeResult/MakeResult.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "./MakeResult.css";
 
 function MakeResult() {
@@ -7,15 +7,18 @@ function MakeResult() {
   const [mentText, setMentText] = useState("어라...?");
   const eggRef = useRef(null);
   const navigate = useNavigate();
-  const location = useLocation();
-  const { monsterId } = location.state || {};
-  const API_URL = process.env.REACT_APP_API_URL;
   const token = localStorage.getItem("jwt");
+  const monsterId  = localStorage.getItem('monsterId');
+  const API_URL = process.env.REACT_APP_API_URL;
+
 
   useEffect(() => {
     const delayAndFetch = () => {
       setTimeout(async () => {
-        if (!monsterId || !token) return;
+        if (monsterId==null){
+          console.alert("잘못된 접근입니다.");
+          navigate(`/make`);
+        }
 
         try{
           const response = await fetch(`${API_URL}/api/monster/${monsterId}/info`, {
@@ -29,13 +32,9 @@ function MakeResult() {
 
           if (data.image) {
             setCukemonImage(data.image);     
+            localStorage.setItem("cukemonImage", data.image);  // 이미지 표시 방법 변경(로컬스토리지에서 꺼내쓰게 함) (5/13수정)
             setMentText("처음보는 포켓몬이 나타났다!");
-            navigate(`/NamePage`, {
-              state: {
-                monsterId: monsterId,
-                image: data.image,
-              },
-            });
+            navigate(`/NamePage`);
           } else {
             throw new Error("이미지 없음");
           }

--- a/cuketmon/src/NamePage/NamePage.js
+++ b/cuketmon/src/NamePage/NamePage.js
@@ -1,64 +1,44 @@
 import React, { useRef,useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate} from "react-router-dom";
 import { useAuth } from "../AuthContext";
 import "./NamePage.css";
 
 function NamePage() {
   const [name, setName] = useState("");
-  const [cukemonImage, setCukemonImage] = useState("/Menubar/egg.png");
   const navigate = useNavigate();
   const { token: contextToken } = useAuth();
   const token = contextToken || localStorage.getItem('jwt');
-  const location = useLocation(); 
-  const maxLength = 12;
   const API_URL = process.env.REACT_APP_API_URL;
-  const cukemonResultImage = location.state?.image; 
+  const cukemonResultImage = localStorage.getItem('cukemonImage')
+  const monsterId = localStorage.getItem("makeResultMonsterId");
 
-
-//뒤로가기 막기 (5/9)
+//뒤로가기 막기 
  const backBlockRef = useRef(false); 
 useEffect(() => {
   const preventGoBack = (event) => {
     if (event.type === "popstate") {
       if (backBlockRef.current) return;
       backBlockRef.current = true;
-
       alert("커켓몬을 두고 떠나지마요 ㅠㅠㅠ");
       window.history.go(1);
-
       setTimeout(() => {
         backBlockRef.current = false;
       }, 500);
     }
   };
-
   window.history.pushState(null, "", window.location.href);
   window.addEventListener("popstate", preventGoBack);
-
   return () => {
     window.removeEventListener("popstate", preventGoBack);
   };
 }, []);
 
-
-  useEffect(() => {
-    if (cukemonResultImage) {
-      setCukemonImage(cukemonResultImage);
-    }
-  }, [cukemonResultImage]);
-
-  const namingCukemon = (e) => {
-    if (e.target.value.length <= maxLength) {
-      setName(e.target.value);
-    }
-  };
-
+  /*데려가기*/
   const handleGoToMypage = async () => {
     if (!name.trim()) {
       alert("이름을 입력해주세요.");
       return;
     }
-   const monsterId = localStorage.getItem("makeResultMonsterId");
     try {
       const response = await fetch(`${API_URL}/api/monster/${monsterId}/name`, {
         method: "PATCH",
@@ -77,9 +57,8 @@ useEffect(() => {
     }
   };
 
-
+   /*재부화*/
   const handleGoTOMakePage = async()=>{
-        const monsterId = localStorage.getItem("makeResultMonsterId");
         const res = await fetch(`${API_URL}/api/monster/${monsterId}/release`, {
           method: "DELETE",
           headers: { 'Authorization': `Bearer ${token}` },
@@ -89,14 +68,13 @@ useEffect(() => {
     }
 
 
-
   return (
     <div className="namePage">
       <div className="nameInputBox">
         <p>Your name?</p>
-        {cukemonImage && (
+        {cukemonResultImage && ( //이미지가 있는 경우에만 렌더링 하도록 함 (5/13 수정)
           <img
-            src={cukemonImage}
+            src={cukemonResultImage}
             alt="커켓몬 이미지"
             className="cukemonImage"
           />
@@ -107,11 +85,11 @@ useEffect(() => {
           <input
             type="text"
             value={name}
-            onChange={namingCukemon}
+            onChange={(e) => setName(e.target.value)}  //이름 지정시 불필요한 코드 삭제 (5/13 수정)
             placeholder="커켓몬 이름 입력"
-            maxLength={maxLength}
+            maxLength={12}
           />
-          <div id="remainWord">{name.length}/{maxLength}자</div>
+          <div id="remainWord">{name.length}/12자</div>
         </div>
 
         <div className="choiceButtons">


### PR DESCRIPTION

## 📂 작업 요약
- 기존에는 state로 커켓몬 이미지를 받았으나 localstorage에 저장 후 꺼내쓰는것으로 변경함
- 생성결과화면: mosterId가 null인경우 처리 정의
- 이름지정화면: 필요없는 공백 제거, 커켓몬 최대 글자수 제한 로직 단순화




## 📎 Issue
<!-- 관련 issue 번호 기입! -->
