### PR TITLE
[fix] 뒤로가기시 release api 실행되던 오류 수정

### DIFF
--- a/cuketmon/src/MakeResult/MakeResult.js
+++ b/cuketmon/src/MakeResult/MakeResult.js
@@ -15,19 +15,27 @@ function MakeResult() {
   /*뒤로가기 시 커켓몬 삭제(커켓몬 생성 취소할 마지막 기회... (5/23 수정)) */
   useEffect(() => {
     window.history.pushState(null, "", window.location.pathname);
-    const handlePopState = async (event) => {
-      event.preventDefault();
-        await fetch(
-          `${API_URL}/api/monster/${monsterId}/release`,
-          {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${token}`}
-          }
-        );
-    };
-    window.addEventListener('popstate', handlePopState);
-  },[]);
+     const handlePopState = async () => {
+    try {
+      await fetch(
+        `${API_URL}/api/monster/${monsterId}/release`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+    } catch (err) {
+      console.error(err);
+    }
+    window.history.back();
+    window.removeEventListener("popstate", handlePopState);
+  };
 
+  window.addEventListener("popstate", handlePopState);
+  return () => {
+    window.removeEventListener("popstate", handlePopState);
+  };
+}, [ monsterId, token]);
 
   useEffect(() => {
     const delayAndFetch = () => {


### PR DESCRIPTION

## 📂 작업 요약
- 다른 페이지에서도 뒤로가기를 누르면 release api가 실행되어 강제로 커켓몬이 버려지는 문제 해결
- 기존 코드는 이벤트리스너를 제거하는 코드가 없어 해당 문제가 발생한 것으로 추정



## 📎 Issue
<!-- 관련 issue 번호 기입! -->
