### PR TITLE
[feat] 로그인화면- refresh token 로직 구현

### DIFF
--- a/cuketmon/package-lock.json
+++ b/cuketmon/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^13.5.0",
         "cuketmon": "file:",
+        "jwt-decode": "^4.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0",
@@ -11054,6 +11055,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/cuketmon/package.json
+++ b/cuketmon/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^13.5.0",
     "cuketmon": "file:",
+    "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.3.0",

--- a/cuketmon/src/AuthContext.js
+++ b/cuketmon/src/AuthContext.js
@@ -1,10 +1,14 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+/*로그인 상태 관련 */
+import React, { createContext, useRef,useContext, useState, useEffect } from 'react';
+import jwtDecode from 'jwt-decode'; 
 
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const [token, setTokenState] = useState(null);
+  const refreshTimeoutRef = useRef(null);
 
+  /* 엑세스 토큰*/
   const setToken = (newToken) => {
     setTokenState(newToken);
     localStorage.setItem('accessToken', newToken);
@@ -17,8 +21,61 @@ export const AuthProvider = ({ children }) => {
     }
   }, []);
 
+   /* access토큰 만료 1분 전 자동 갱신(5/23 수정)*/
+  useEffect(() => {
+    if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+    if (!token) return;
+
+    try {
+      const { exp } = jwtDecode(token);
+      const expiresAt = exp * 1000; //일단은 1시간이라고 둠
+      const now = Date.now();
+      const refreshIn = expiresAt - now - 60 * 1000;
+      if (refreshIn > 0) {
+        refreshTimeoutRef.current = setTimeout(refreshAccessToken, refreshIn);
+      } else {
+        refreshAccessToken(); //이미 만료된 상태면 뱌로 갱신
+      }
+    } catch (e) {
+      console.error('refreshToken 갱신 오류', e);
+    }
+
+    return () => {
+      if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+    };
+  }, [token]);
+
+  /* 리프레시 토큰 (엑세스토큰과 동일 API 사용) */
+  const refreshAccessToken = async () => {
+    const res = await fetch('/oauth2/authorization/kakao', {
+      method: 'GET',
+      credentials: 'include',
+    });
+
+    if (!res.ok)throw new Error('refreshToken 에러');
+    const { accessToken: newToken } = await res.json();
+    setToken(newToken);
+    return newToken;
+  };
+
+  const apiFetch = async (url, options = {}) => {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+
+    const response = await fetch(url, {
+      ...options,
+      headers,
+      credentials: 'include',
+    });
+
+    return response;
+  };
+
   return (
-    <AuthContext.Provider value={{ token, setToken }}>
+    <AuthContext.Provider value={{ token, setToken, apiFetch }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION


## 📂 작업 요약
- refreshToken으로 accessToken을 갱신하는 로직 추가.
- acessToken 만료 1분전 자동 갱신 되도록함.


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
