### PR TITLE
[fix] affinity 최대값 수정

### DIFF
--- a/BE/src/main/java/cuketmon/monster/constant/MonsterConst.java
+++ b/BE/src/main/java/cuketmon/monster/constant/MonsterConst.java
@@ -16,6 +16,6 @@ public class MonsterConst {
     public static final int TOY_MINUS = 1;
     public static final int AFFINITY_PLUS = 5;
 
-    public static final int BOUND = 100;
+    public static final int BOUND = 999;
 
 }

--- a/BE/src/main/java/cuketmon/monster/embeddable/Affinity.java
+++ b/BE/src/main/java/cuketmon/monster/embeddable/Affinity.java
@@ -18,7 +18,7 @@ public class Affinity {
     public int increase(int amount) {
         this.count += amount;
         if (this.count >= BOUND) {
-            this.count %= BOUND;
+            this.count = BOUND;
             return 1;
         }
         return 0;


### PR DESCRIPTION
## 📂 작업 요약
<!-- 작업내용을 요약해주시면 됩니다. -->
- 우리는 lv이 없기 때문에 최대 값을 999로 지정
- 표기 max만 999로 하고 스피드 능력치는 계속 올라감


## 📎 Issue
<!-- 관련 issue 번호 기입! -->
x